### PR TITLE
Allow to call anlayze.sh from anywhere for some systems

### DIFF
--- a/analyze/analyze.sh
+++ b/analyze/analyze.sh
@@ -18,6 +18,7 @@ case "${uname_output}" in
     *)          machine="UNKNOWN:${uname_output}"
 esac
 
+echo "detected os-type $machine -- resolve enabled: $do_resolve"
 
 # the script takes a single argument
 if [[ -z "$*" ]]; then
@@ -41,7 +42,7 @@ fi
 # the lib directory that is also contained in the same directory.
 if $do_resolve; then
     script_dir="$(realpath -s "$(dirname "$(readlink -s -f "${BASH_SOURCE[0]}")")")"
-    cd "$script_dir"
+    cd "$script_dir" || { echo "failed to change into binary dir $script_dir"; exit 1; }
     echo "$script_dir"
 fi
 

--- a/analyze/analyze.sh
+++ b/analyze/analyze.sh
@@ -1,6 +1,51 @@
 #!/bin/bash
+set -u
+
+# The sript requires an installed version of arangodb or at least a way to call
+# the arangosh executable from anywhere. We try to do path resolving on best a
+# best effort basis for some systems.
+# If it does not work for you change the `do_resolve` for your system to false.
+# In systems that do not have do_resolve enabled you need to be in the directory
+# in which this script is contained to make it work.
+
+do_resolve=false;
+uname_output="$(uname -s)"
+case "${uname_output}" in
+    Linux*)     machine=Linux; do_resolve=true;;
+    Darwin*)    machine=Mac;;
+    CYGWIN*)    machine=Cygwin;;
+    MINGW*)     machine=MinGw;;
+    *)          machine="UNKNOWN:${uname_output}"
+esac
+
+
+# the script takes a single argument
+if [[ -z "$*" ]]; then
+    echo "no file provided"
+    exit 1
+fi
+
+if $do_resolve; then
+    file_name="$(realpath -s "$(readlink -s -f "$1")")"
+    if [[ -z "$file_name" ]]; then
+        echo "file resolution failed"
+        exit 1
+    fi
+    echo "full path of json: $file_name"
+else
+    file_name="$1"
+fi
+
+
+# Try to enter the dir that contains this file as we require to be relative to
+# the lib directory that is also contained in the same directory.
+if $do_resolve; then
+    script_dir="$(realpath -s "$(dirname "$(readlink -s -f "${BASH_SOURCE[0]}")")")"
+    cd "$script_dir"
+    echo "$script_dir"
+fi
 
 arangosh \
     --server.endpoint none \
     --javascript.execute lib/analyze.js \
-    -- "$@"
+    -- "$file_name"

--- a/analyze/analyze.sh
+++ b/analyze/analyze.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -u
 
 # The sript requires an installed version of arangodb or at least a way to call


### PR DESCRIPTION
`./analyze/analyze.sh production/dump.json`
will now work instead of yielding errors.

The changes will most probably work out of the box for other systems.
OSX has probably a too old userland to let it work out of the box, but
path resolving could be implemented in a different way.