### PR TITLE
allow invoking the scripts from other directory

### DIFF
--- a/maintenance.sh
+++ b/maintenance.sh
@@ -1,4 +1,20 @@
 #!/bin/sh
+if which realpath > /dev/null; then
+  true
+else
+  realpath() {
+    OURPWD=$PWD
+    cd "$(dirname "$1")"
+    LINK=$(readlink "$(basename "$1")")
+    while [ "$LINK" ]; do
+      cd "$(dirname "$LINK")"
+      LINK=$(readlink "$(basename "$1")")
+    done
+    REALPATH="$PWD/$(basename "$1")"
+    cd "$OURPWD"
+    echo "$REALPATH"
+  }
+fi
 
 if test -z "$ARANGOSH"; then
     arangosh=`which arangosh`

--- a/maintenance.sh
+++ b/maintenance.sh
@@ -61,8 +61,14 @@ done
 
 shift "$nargs"
 
+myPath="`realpath $0`"
+myPath="`dirname $myPath`"
+if [ "x$myPath" = "x" ]; then
+    myPath="."
+fi
+
 if test "$noEndpoint" -eq 1; then
-    $arangosh --javascript.execute ./lib/index.js --server.endpoint none "$@" $dashDash $scriptArgs
+    $arangosh --javascript.execute "$myPath"/lib/index.js --server.endpoint none "$@" $dashDash $scriptArgs
 else
-    $arangosh --javascript.execute ./lib/index.js "$@" $dashDash $scriptArgs
+    $arangosh --javascript.execute "$myPath"/lib/index.js "$@" $dashDash $scriptArgs
 fi


### PR DESCRIPTION
the previous version required that the scripts were executed from inside
the maintenance scripts directory, so that cwd was equal to
`cluster-maintenance`. the changes in this commit should allow invoking the maintenance scripts from an arbitrary directory

this was requested as a feature in https://arangodb.atlassian.net/browse/ES-986