### PR TITLE
allow tasks to work with >= 3.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ to it.
 
 In order to use these scripts, a working installation of the
 ArangoShell (arangosh) is needed. The scripts currently support
-ArangoDB versions 3.6, 3.7, 3.8 and 3.9. Support for further upcoming stable 
+ArangoDB versions 3.8, 3.9 and 3.10. Support for further upcoming stable 
 ArangoDB releases will be added once they are released.
 
 Please note, that some tasks are only available in certain

--- a/lib/helper-cleanout-server.js
+++ b/lib/helper-cleanout-server.js
@@ -141,7 +141,7 @@ exports.run = function (extra, args, cleanout) {
 
     const t2 = new Date();
     print("INFO " + (t2));
-    print("INFO waiting for job to finished");
+    print("INFO waiting for job to finish");
 
     internal.wait(sleep / 10);
   }

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -356,7 +356,7 @@ const countArgs = (usageArray) => {
 
 const checkArgs = (task, args) => {
   args.shift(); // remove task name from args
-
+  
   const proArgs = args.length;
   const reqArgs = countArgs(task.args);
 
@@ -369,17 +369,23 @@ const checkArgs = (task, args) => {
 
   for (let i = 0; i < proArgs; i++) {
     const given = args[i];
+
+    if (i >= task.args.length) {
+      // too many arguments
+      print("ignoring superfluous argument #" + i + "': " + given + "'");
+      continue;
+    }
     const toSet = task.args[i];
     try {
       switch (toSet.type) {
-      case 'string':
-        toSet.value = given;
-        break;
-      case 'jsonfile':
-        toSet.value = readJsonFile(given, true /* must read */);
-        break;
-      case 'boolean':
-      case 'bool': {
+        case 'string':
+          toSet.value = given;
+          break;
+        case 'jsonfile':
+          toSet.value = readJsonFile(given, true /* must read */);
+          break;
+        case 'boolean':
+        case 'bool': {
           const v = given.toLowerCase();
           if (v === 'true' || v === '1' || v === 'y') {
             toSet.value = true;
@@ -387,12 +393,12 @@ const checkArgs = (task, args) => {
             toSet.value = false;
           }
         }
-        break;
-      case 'int':
-        toSet.value = Number.parseInt(given);
-        break;
-      default:
-        fatal("Unknown argument type: " + toSet.type);
+          break;
+        case 'int':
+          toSet.value = Number.parseInt(given);
+          break;
+        default:
+          fatal("Unknown argument type: " + toSet.type);
       }
     } catch (ex) {
       fatal("Error while parsing value for argument '" + task.name + "' message: " + ex);
@@ -403,8 +409,7 @@ const checkArgs = (task, args) => {
 };
 
 const checkGlobalArgs = (args) => {
-  const options = {
-  };
+  const options = {};
 
   let l = args.length;
 
@@ -436,7 +441,7 @@ const getValue = (name, args) => {
   // handle default values here?
   const rv = args.find(x => x.name === name);
   if (rv === undefined) {
-      fatal("Trying to access undefined argument: '" + name + "'");
+    fatal("Trying to access undefined argument: '" + name + "'");
   }
   return rv.value;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -123,11 +123,12 @@
   };
 
   const loadTasks = function (options) {
+    let printDisableWarning = true;
     let tasks = fs.listTree(fs.join(__dirname, "tasks")).filter(function (task) {
       return task.match(/\.js$/);
     }).filter(function (name) {
       return !name.match(/-disabled/);
-    }).map(function (task) {
+    }).sort().map(function (task) {
       let file = fs.join(__dirname, "tasks", task);
       try {
         let t = require(file);
@@ -142,10 +143,18 @@
     }).filter(function (task) {
       let good = semver.satisfies(shellVersion, task.requires) || isDevel || options.force || options.ignoreVersion;
       if (!good) {
-        print("- " + task.name + ": removing this task because of mismatching shell version (" + shellVersion + ") requires: " + task.requires);
+        if (printDisableWarning) {
+          print("Disabling the following tasks:");
+          printDisableWarning = false;
+        }
+        print("- " + task.name + ": disabling this task because of mismatching shell version (" + shellVersion + ") requires: " + task.requires);
       }
       return good;
     });
+        
+    if (!printDisableWarning) {
+      print();
+    }
     tasks.sort(function (lhs, rhs) {
       return compareTasks(lhs, rhs);
     });

--- a/lib/tasks/analyze.js
+++ b/lib/tasks/analyze.js
@@ -13,7 +13,7 @@ exports.args = [
 exports.args_arangosh = "| --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Performs health analysis on your cluster and produces input files for other cleanup tasks.";
 exports.selfTests = ["arango", "db"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Runs the analyze task against a cluster. It will create files and print
 commands to fix some known problems like the removal of zombies or dead

--- a/lib/tasks/change-collection-wait-for-sync.js
+++ b/lib/tasks/change-collection-wait-for-sync.js
@@ -25,9 +25,9 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Changes the waitForSync in all collections";
 exports.selfTests = ["arango", "db", "coordinatorConnection"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
-Shows properties of all collections.
+Changes the waitForSync in all collections.
 `;
 
 exports.run = function (extra, args) {

--- a/lib/tasks/change-database-write-concern.js
+++ b/lib/tasks/change-database-write-concern.js
@@ -31,7 +31,7 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Changes write concern of a database";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.6.0 - 3.9.99";
+exports.requires = "3.6.0 - 3.10.99";
 exports.info = `
 Changes write concern value of a database.
 `;

--- a/lib/tasks/change-latest-id.js
+++ b/lib/tasks/change-latest-id.js
@@ -13,7 +13,7 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Change the /arango/Sync/LatestID.";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Change the entry /arango/Sync/LatestID. You NEED to restart the cluster afterwards.
 `;

--- a/lib/tasks/cleanout-server.js
+++ b/lib/tasks/cleanout-server.js
@@ -12,7 +12,7 @@ exports.args = [
 exports.args_arangosh = "| --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Cleans out a server.";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.6.0 - 3.9.99";
+exports.requires = "3.6.0 - 3.10.99";
 exports.info = `
 This task cleans out a DBserver.
 `;

--- a/lib/tasks/clear-cleanout-server.js
+++ b/lib/tasks/clear-cleanout-server.js
@@ -13,7 +13,7 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Clears cleanout server list";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.6.0 - 3.9.99";
+exports.requires = "3.6.0 - 3.10.99";
 exports.info = `
 Removes the cleaned out servers at '/arango/Target/CleanedServers'.
 `;

--- a/lib/tasks/clear-maintenance.js
+++ b/lib/tasks/clear-maintenance.js
@@ -7,7 +7,7 @@ exports.args = [];
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Clears maintenance and hot-backup flags.";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Clears the maintenance and hot-backup flags in the supervision.
 `;

--- a/lib/tasks/collect-db-info.js
+++ b/lib/tasks/collect-db-info.js
@@ -12,7 +12,7 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint SINGLESERVER-OR-COORDINATOR --server.database DATABASE";
 exports.description = "Dumps information about the database and collection.";
 exports.selfTests = ["arango", "db"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Dumps information about the database and collections.
 `;

--- a/lib/tasks/create-missing-collections.js
+++ b/lib/tasks/create-missing-collections.js
@@ -12,14 +12,14 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint COORDINATOR";
 exports.description = "Adds missing collections found by the analyze task.";
 exports.selfTests = ["arango", "db", "coordinatorConnection"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Adds missing collections found by the analyze task.
 `;
 
 exports.run = function (extra, args) {
   // imports
-  const _ = require('underscore');
+  const _ = require('lodash');
   const helper = require('../helper.js');
   let missingCollections = helper.getValue("missing-collections-file", args);
 

--- a/lib/tasks/create-missing-system-collections.js
+++ b/lib/tasks/create-missing-system-collections.js
@@ -6,7 +6,7 @@ exports.args = [ ];
 exports.args_arangosh = "--server.endpoint COORDINATOR";
 exports.description = "Adds missing system collections for all databases (does not require the analyze task).";
 exports.selfTests = ["arango", "db", "coordinatorConnection"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Helper script to create missing system collections. It will iterate over the list
 of databases and check for the availability of the default system collections

--- a/lib/tasks/create-move-analysis.js
+++ b/lib/tasks/create-move-analysis.js
@@ -13,7 +13,7 @@ exports.args = [
 exports.args_arangosh = "| --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Creates analysis for a plan to rebalance shards in your cluster.";
 exports.selfTests = ["arango", "db"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 This task creates operations that can be applied to rebalance shards in a
 cluster that has become inbalanced due to server failures.
@@ -30,7 +30,7 @@ exports.run = function (extra, args) {
   // imports
   const helper = require('../helper.js');
   const fs = require('fs');
-  const _ = require('underscore');
+  const _ = require('lodash');
 
   // variables
   const file = helper.getValue("dump-file", args);

--- a/lib/tasks/create-move-plan.js
+++ b/lib/tasks/create-move-plan.js
@@ -36,7 +36,7 @@ exports.run = function (extra, args) {
   // imports
   const helper = require('../helper.js');
   const fs = require('fs');
-  const _ = require('underscore');
+  const _ = require('lodash');
 
   // variables
   const file = helper.getValue("dump-file", args);

--- a/lib/tasks/detect-permanently-out-of-sync.js
+++ b/lib/tasks/detect-permanently-out-of-sync.js
@@ -14,13 +14,13 @@ exports.args = [
     name: 'calculate-hashes',
     optional: true,
     type: 'bool',
-    description: 'calculate hashes for comarison rather than counts only'
+    description: 'calculate hashes for comparison rather than counts only'
   }
 ];
 exports.args_arangosh = ' --server.endpoint COORDINATOR';
 exports.description = 'Shows multiple levels of intrusive synchronization issue detection';
 exports.selfTests = ['arango', 'leaderAgencyConnection'];
-exports.requires = '3.3.23 - 3.9.99';
+exports.requires = '3.3.23 - 3.10.99';
 exports.info = `
 Multiple levels of intrusive synchronization issue detection.
 `;

--- a/lib/tasks/dump.js
+++ b/lib/tasks/dump.js
@@ -11,7 +11,7 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Gets agency-dump from an agent.";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Gets agency-dump from an agency leader.
 `;

--- a/lib/tasks/execute-compaction.js
+++ b/lib/tasks/execute-compaction.js
@@ -13,7 +13,7 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Runs compaction on server";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.5.6 - 3.9.99";
+exports.requires = "3.5.6 - 3.10.99";
 exports.info = `
 Runs the compaction on all collections on one server.
 `;

--- a/lib/tasks/execute-move-plan.js
+++ b/lib/tasks/execute-move-plan.js
@@ -26,7 +26,7 @@ This operation will do the actual rebalancing of a cluster.
 
 exports.run = function (extra, args) {
   const helper = require('../helper.js');
-  const _ = require('underscore');
+  const _ = require('lodash');
 
   let shardsToMove = helper.getValue("move-plan-file", args);
   let amount = helper.getValue("amount", args);

--- a/lib/tasks/force-failover.js
+++ b/lib/tasks/force-failover.js
@@ -12,7 +12,7 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Performs forced failover as calculated by analyze task.";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Executes force failover as calculated by the analyze task.
 `;

--- a/lib/tasks/help.js
+++ b/lib/tasks/help.js
@@ -54,5 +54,8 @@ exports.run = function (extra, args) {
     print("Usage for task: " + taskName + "\n");
     helper.printUsage(tasks[taskName]);
   }
+
+  print();
+  print("To skip version compatibility checks for tasks, please rerun with `--ignore-version`");
   print();
 };

--- a/lib/tasks/history.js
+++ b/lib/tasks/history.js
@@ -11,7 +11,7 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint COORDINATOR";
 exports.description = "Gets agency-history from a coordinator.";
 exports.selfTests = ["arango", "db", "coordinatorConnection"];
-exports.requires = "3.4.6 - 3.9.99";
+exports.requires = "3.4.6 - 3.10.99";
 exports.info = `
 Gets agency-history from a coordinator.
 `;

--- a/lib/tasks/post-agency-plan.js
+++ b/lib/tasks/post-agency-plan.js
@@ -24,7 +24,7 @@ exports.run = function (extra, args) {
 
   // imports
   const helper = require('../helper.js');
-  const _ = require('underscore');
+  const _ = require('lodash');
 
   // needs to be connected to the leader agent
   helper.checkLeader();

--- a/lib/tasks/post-agency-plan.js
+++ b/lib/tasks/post-agency-plan.js
@@ -13,11 +13,11 @@ exports.args = [
 exports.args_arangosh = "| --server.endpoint LEADER-AGENT";
 exports.description = "Posts an agency dump to an ArangoDB agency leader.";
 exports.selfTests = ["arango", "db"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 This task takes an agency dump file, modifies it to fit to the new server and post it.
 
-    ./arangodb-debug.sh post-agency-plan --server.endpoint tcp://(ip-address):(agency-port)> agencyDump.json
+    ./maintenance.sh post-agency-plan --server.endpoint tcp://(ip-address):(agency-port)> agencyDump.json
 `;
 
 exports.run = function (extra, args) {

--- a/lib/tasks/remove-cleaned-failovers.js
+++ b/lib/tasks/remove-cleaned-failovers.js
@@ -13,7 +13,7 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Clears cleaned failover candidates found by analyze task.";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Removes cleaned failover candidates found by the analyze task.
 `;

--- a/lib/tasks/remove-dead-primaries.js
+++ b/lib/tasks/remove-dead-primaries.js
@@ -13,7 +13,7 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Removes dead primaries found by analyze task.";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Removes dead primaries found by the analyze task.
 `;
@@ -21,7 +21,7 @@ Removes dead primaries found by the analyze task.
 exports.run = function (extra, args) {
 
   // imports
-  const _ = require('underscore');
+  const _ = require('lodash');
   const helper = require('../helper.js');
   let zombies = helper.getValue("dead-primaries-file", args);
 

--- a/lib/tasks/remove-failed-followers.js
+++ b/lib/tasks/remove-failed-followers.js
@@ -13,7 +13,7 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Clears failed followers found by analyze task.";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Removes failed followers found by the analyze task.
 `;

--- a/lib/tasks/remove-skeleton-databases.js
+++ b/lib/tasks/remove-skeleton-databases.js
@@ -21,7 +21,7 @@ Removes skeleton databases.
 exports.run = function (extra, args) {
 
   // imports
-  const _ = require('underscore');
+  const _ = require('lodash');
   const helper = require('../helper.js');
 
   let skeletons = helper.getValue("remove-skeleton-database-file", args);

--- a/lib/tasks/remove-skeleton-databases.js
+++ b/lib/tasks/remove-skeleton-databases.js
@@ -13,7 +13,7 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Removes skeleton databases found by analyze task.";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Removes skeleton databases.
 `;

--- a/lib/tasks/remove-zombie-analyzer-revisions.js
+++ b/lib/tasks/remove-zombie-analyzer-revisions.js
@@ -13,7 +13,7 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Removes dead analyzer revisions found by analyze task.";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.7.0 - 3.9.99";
+exports.requires = "3.7.0 - 3.10.99";
 exports.info = `
 Removes dead analyzer revisions found by the analyze task.
 `;

--- a/lib/tasks/remove-zombie-callbacks.js
+++ b/lib/tasks/remove-zombie-callbacks.js
@@ -13,7 +13,7 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Removes zombie callbacks found by analyze task.";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Removes zombies callbacks found by the analyze task.
 `;

--- a/lib/tasks/remove-zombie-coordinators.js
+++ b/lib/tasks/remove-zombie-coordinators.js
@@ -13,7 +13,7 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Removes dead coordinators found by analyze task.";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Removes dead coordinators found by the analyze task.
 `;

--- a/lib/tasks/remove-zombies.js
+++ b/lib/tasks/remove-zombies.js
@@ -13,7 +13,7 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Removes zombie collections found by analyze task.";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Removes zombies found by the analyze task.
 `;

--- a/lib/tasks/remove-zombies.js
+++ b/lib/tasks/remove-zombies.js
@@ -20,7 +20,7 @@ Removes zombies found by the analyze task.
 
 exports.run = function (extra, args) {
   // imports
-  const _ = require('underscore');
+  const _ = require('lodash');
   const helper = require('../helper.js');
   let zombies = helper.getValue("zombie-file", args);
 

--- a/lib/tasks/repair-broken-edge-indexes.js
+++ b/lib/tasks/repair-broken-edge-indexes.js
@@ -13,7 +13,7 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint COORDINATOR";
 exports.description = "Repairs broken edge indexes found by analyze task.";
 exports.selfTests = ["arango", "db", "coordinatorConnection"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Repairs broken edge index definition found by analyze task.
 `;

--- a/lib/tasks/repair-permanently-out-of-sync.js
+++ b/lib/tasks/repair-permanently-out-of-sync.js
@@ -26,7 +26,7 @@ exports.args = [
 exports.args_arangosh = ' --server.endpoint COORDINATOR';
 exports.description = 'Resolves permantly out of sync issue';
 exports.selfTests = ['arango', 'leaderAgencyConnection'];
-exports.requires = '3.3.23 - 3.9.99';
+exports.requires = '3.3.23 - 3.10.99';
 exports.info = `
 Solve dis-synced shards
 `;

--- a/lib/tasks/repair-sharding-strategy.js
+++ b/lib/tasks/repair-sharding-strategy.js
@@ -19,7 +19,7 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Clears cleaned failover candidates found by analyze task.";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Repairs missing sharding strategy.
 `;

--- a/lib/tasks/repair-unplanned-failover.js
+++ b/lib/tasks/repair-unplanned-failover.js
@@ -13,7 +13,7 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Clears unplanned failover candidates found by analyze task.";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.6.1 - 3.9.99";
+exports.requires = "3.6.1 - 3.10.99";
 exports.info = `
 Repairs unplanned failover candidates.
 `;

--- a/lib/tasks/resign-leadership.js
+++ b/lib/tasks/resign-leadership.js
@@ -12,7 +12,7 @@ exports.args = [
 exports.args_arangosh = "| --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Resigns leadership.";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.6.0 - 3.9.99";
+exports.requires = "3.6.0 - 3.10.99";
 exports.info = `
 This task resigns all leadership of a DBserver.
 `;

--- a/lib/tasks/show-agents.js
+++ b/lib/tasks/show-agents.js
@@ -6,7 +6,7 @@ exports.args = [];
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Shows the status of the agents.";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Shows the status of the agents.
 `;

--- a/lib/tasks/show-analyzer-revisions.js
+++ b/lib/tasks/show-analyzer-revisions.js
@@ -6,7 +6,7 @@ exports.args = [];
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Shows the list of the analyzer revisions.";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.7.0 - 3.9.99";
+exports.requires = "3.7.0 - 3.10.99";
 exports.info = `
 Shows the list of the analyzer revisions.
 `;

--- a/lib/tasks/show-collections.js
+++ b/lib/tasks/show-collections.js
@@ -13,7 +13,7 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Shows information about all collections";
 exports.selfTests = ["arango", "db", "coordinatorConnection"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Shows properties of all collections.
 `;

--- a/lib/tasks/show-dbstats.js
+++ b/lib/tasks/show-dbstats.js
@@ -6,7 +6,7 @@ exports.args = [];
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Shows statistics from database servers";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Shows all DB statictics from DBservers.
 `;

--- a/lib/tasks/show-documents.js
+++ b/lib/tasks/show-documents.js
@@ -19,7 +19,7 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Shows number of documents.";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Shows the number of documents in all collections in all databases.
 `;

--- a/lib/tasks/show-move-shards.js
+++ b/lib/tasks/show-move-shards.js
@@ -13,14 +13,14 @@ exports.args = [
 exports.args_arangosh = "| --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Allows to inspect shards being moved.";
 exports.selfTests = ["arango", "db"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Allows to track progress of shard movement.
 `;
 exports.run = function (extra, args) {
   // modules
   const helper = require('../helper.js');
-  const _ = require('underscore');
+  const _ = require('lodash');
   const AsciiTable = require('../3rdParty/ascii-table');
 
   // variables

--- a/lib/tasks/show-servers.js
+++ b/lib/tasks/show-servers.js
@@ -5,7 +5,7 @@ exports.args = [];
 exports.args_arangosh = "| --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Shows a list of all servers.";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.6.0 - 3.9.99";
+exports.requires = "3.6.0 - 3.10.99";
 exports.info = `
 This tasks shows all servers.
 `;

--- a/lib/tasks/show-supervision.js
+++ b/lib/tasks/show-supervision.js
@@ -6,7 +6,7 @@ exports.args = [];
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Shows the state of the supervision.";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
   Shows the state of the supervision, maintenance and hot-backup.
 `;

--- a/lib/tasks/trash-dbserver.js
+++ b/lib/tasks/trash-dbserver.js
@@ -13,7 +13,7 @@ exports.args = [
 exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
 exports.description = "Moves a DBserver to the trash bin.";
 exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Moves a DBserver to the trash bin.
 `;

--- a/lib/tasks/users-permissions.js
+++ b/lib/tasks/users-permissions.js
@@ -12,7 +12,7 @@ exports.args = [
 exports.args_arangosh = "| --server.endpoint SINGLESERVER-OR-COORDINATOR";
 exports.description = "Extracts all users and permissions from the system database.";
 exports.selfTests = ["arango", "db"];
-exports.requires = "3.3.23 - 3.9.99";
+exports.requires = "3.3.23 - 3.10.99";
 exports.info = `
 Extracts all available users and permissions from the _system database
 and prints the information.


### PR DESCRIPTION
None of the tasks in this repository was declared to be compatible with 3.10.*.
This PR fixes that.

Some tasks needed to be adjusted, because they relied on the `underscore` JavaScript module, which is not available in the 3.10
arangosh JavaScript components anymore.

This fixes https://arangodb.atlassian.net/browse/BTS-1078.

The adjusted tasks were tested manually against 3.10.0, except the following (for which I had no input data to test with):

* force-failover
* post-agency-plan
* remove-cleaned-failovers
* remove-failed-followers
* remove-skeleton-databases
* remove-zombie-analyzer-revisions
* remove-zombie-callbacks
* remove-zombie-coordinators
* remove-zombies
* repair-broken-edge-indexes
* repair-sharding-strategy
* repair-unplanned-failover

It would be good to have these tasks validated for actual compatiblity by another person.