### PR TITLE
Add helper tasks for latest id handling

### DIFF
--- a/lib/tasks/change-latest-id.js
+++ b/lib/tasks/change-latest-id.js
@@ -1,7 +1,7 @@
 /* jshint globalstrict:false, strict:false, sub: true */
 /* global print */
 exports.name = "change-latest-id";
-exports.group = "change latest id";
+exports.group = "latest id";
 exports.args = [
   {
     "name": "value",

--- a/lib/tasks/increase-latest-id.js
+++ b/lib/tasks/increase-latest-id.js
@@ -36,7 +36,7 @@ exports.run = function (extra, args) {
     data[0].push(obj);
 
     const prec = {};
-    prec[k] = { "old": previous};
+    prec[k] = { "old": previous };
     data[0].push(prec);
 
     print("INFO: executing write of", JSON.stringify(data));

--- a/lib/tasks/increase-latest-id.js
+++ b/lib/tasks/increase-latest-id.js
@@ -1,0 +1,52 @@
+/* jshint globalstrict:false, strict:false, sub: true */
+/* global print */
+exports.name = "increase-latest-id";
+exports.group = "latest id";
+exports.args = [
+  {
+    "name": "value",
+    "optional": false,
+    "type": "int"
+  }
+];
+
+exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
+exports.description = "Increase the /arango/Sync/LatestID.";
+exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
+exports.requires = "3.3.23 - 3.10.99";
+exports.info = `
+Increase the entry /arango/Sync/LatestID only if it is lower than some threshold value. You NEED to restart the cluster afterwards.
+`;
+
+exports.run = function (extra, args) {
+  const helper = require('../helper.js');
+  const value = helper.getValue("value", args);
+  
+  let data = [['/arango/Sync/LatestID']];
+  let res = helper.httpWrapper('POST', '/_api/agency/read', data);
+  const previous = res[0]["arango"]["Sync"]["LatestID"];
+
+  if (previous >= value) {
+    print("INFO: no need to bump latest id to " + value + ", because it is already at " + previous);
+  } else {
+    const k = '/arango/Sync/LatestID';
+    let data = [[]];
+    const obj = {};
+    obj[k] = value;
+    data[0].push(obj);
+
+    const prec = {};
+    prec[k] = { "old": previous};
+    data[0].push(prec);
+
+    print("INFO: executing write of", JSON.stringify(data));
+    const writeRes = helper.httpWrapper('POST', '/_api/agency/write', data);
+
+    if (writeRes.results[0] === 0) {
+      print("WARNING: pre-condition failed, maybe latest id was modified in between");
+    } else {
+      print("INFO: " + JSON.stringify(writeRes));
+      print("INFO: latest id bumped from " + previous + " to " + value);
+    }
+  }
+};

--- a/lib/tasks/show-latest-id.js
+++ b/lib/tasks/show-latest-id.js
@@ -1,0 +1,23 @@
+/* jshint globalstrict:false, strict:false, sub: true */
+/* global print */
+exports.name = "show-latest-id";
+exports.group = "latest id";
+exports.args = [
+];
+
+exports.args_arangosh = " --server.endpoint AGENT-OR-COORDINATOR";
+exports.description = "Show the /arango/Sync/LatestID.";
+exports.selfTests = ["arango", "db", "leaderAgencyConnection"];
+exports.requires = "3.3.23 - 3.10.99";
+exports.info = `
+Read the entry /arango/Sync/LatestID.
+`;
+
+exports.run = function (extra, args) {
+  const helper = require('../helper.js');
+  const data = [['/arango/Sync/LatestID']];
+
+  const res = helper.httpWrapper('POST', '/_api/agency/read', data);
+
+  print("INFO: " + JSON.stringify(res));
+};

--- a/lib/tasks/show-latest-id.js
+++ b/lib/tasks/show-latest-id.js
@@ -19,5 +19,5 @@ exports.run = function (extra, args) {
 
   const res = helper.httpWrapper('POST', '/_api/agency/read', data);
 
-  print("INFO: " + JSON.stringify(res));
+  print("INFO: latest id is: " + res[0]["arango"]["Sync"]["LatestID"]);
 };


### PR DESCRIPTION
This PR adds the following helper tasks:	
* show-latest-id: will show the current value of /arango/Sync/LatestID
* increase-latest-id: will increase the value of /arango/Sync/LatestID to the specified value if it's currently below that value