### PR TITLE
Avoid a crash in case a db object is not there

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -473,7 +473,19 @@ const extractDatabases = function (info, dump) {
   const allCollections = dump.arango.Plan.Collections;
 
   _.each(allCollections, function (collections, dbName) {
-    const database = databases[dbName];
+    let database = databases[dbName];
+    if (database === undefined) {
+      print("Attention: Database with name'", dbName, "' is not in Databases");
+      database = {
+        collections:[],
+        shards: [],
+        leaders: [],
+        followers: [],
+        realLeaders: [],
+        isSystem: (dbName.charAt(0) === '_'),
+        data: {}
+      };
+    }
 
     _.each(collections, function (collection, cId) {
       if (collection.name === undefined && collection.id === undefined) {


### PR DESCRIPTION
I ran into an agency dump in which there were some collection objects
in a database which had already been deleted in /arango/Databases.
This lead to a crash in the analysis tool. This PR fixes this problem.
